### PR TITLE
feat(Q4P-1556): Removed custom bearer auth component

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -12,7 +12,6 @@
 
   <body>
 
-    <center><input style="position:relative; top:20px; box-shadow: 10px 10px #71D60A; border-width: 3px; border-color: red;" id="bearer-token-input" size="50" type="text" placeholder="Enter Bearer Token here" value="Enter bearer token here" /></center>
     <div id="swagger-ui"></div>
     <script src="./swagger-ui-bundle.js" charset="UTF-8"> </script>
     <script src="./swagger-ui-standalone-preset.js" charset="UTF-8"> </script>
@@ -47,15 +46,7 @@
           plugins: [
             SwaggerUIBundle.plugins.DownloadUrl
           ],
-          layout: "StandaloneLayout",
-          requestInterceptor: function (req) {
-            req.headers = {
-            'Authorization': 'Bearer ' + document.getElementById('bearer-token-input').value
-            , 'Accept': 'application/json',
-            'Content-Type': 'application/json'
-            };
-            return req;
-          },
+          layout: "StandaloneLayout"
         });
         
         // Remove topbar


### PR DESCRIPTION
Removed custom bearer auth component in favour of adding it to our swagger.yaml. 
Updated swagger to our latest one to test it in local html
<img width="1192" alt="Screenshot 2022-09-22 at 16 21 17" src="https://user-images.githubusercontent.com/72214338/191773218-a5d83434-8d7f-4e9d-a75f-3cf2f2a2d34a.png">
